### PR TITLE
Edge Direction

### DIFF
--- a/nx_altair/core.py
+++ b/nx_altair/core.py
@@ -2,7 +2,6 @@ import pandas as pd
 import networkx as nx
 import altair as alt
 from ._utils import despine
-from math import sin, cos, atan2
 
 def to_pandas_nodes(G, pos):
     """Convert Graph nodes to pandas DataFrame that's readable to Altair.

--- a/nx_altair/core.py
+++ b/nx_altair/core.py
@@ -2,7 +2,7 @@ import pandas as pd
 import networkx as nx
 import altair as alt
 from ._utils import despine
-from math import atan2
+from math import sin, cos, atan2
 
 def to_pandas_nodes(G, pos):
     """Convert Graph nodes to pandas DataFrame that's readable to Altair.
@@ -77,7 +77,7 @@ def to_pandas_edges(G, pos, **kwargs):
 
     return df
 
-def to_pandas_edges_arrows(G, pos, arrow_width, **kwargs):
+def to_pandas_edges_arrows(G, pos, arrow_length, **kwargs):
     """Convert Graph edges to pandas DataFrame that's readable to Altair.
     """
     # Get all attributes in nodes
@@ -89,16 +89,17 @@ def to_pandas_edges_arrows(G, pos, arrow_width, **kwargs):
 
     # Build a dataframe for all edges and their attributes
     df = pd.DataFrame(
-        index=range(G.size()),
+        index=range(G.size()*2),
         columns=attributes
     )
 
 
     # Add node data to dataframe.
     for i, e in enumerate(G.edges):
-        idx = i
-        Dy = pos[e[0]][1]-pos[e[0]][0]
-        Dx = pos[e[1]][1]-pos[e[1]][0]
+        idx = i*2
+        Dy = pos[e[1]][1]-pos[e[0]][1]
+        Dx = pos[e[1]][0]-pos[e[0]][0]
+
         data1 = dict(
             edge=i,
             source=e[0],
@@ -106,13 +107,21 @@ def to_pandas_edges_arrows(G, pos, arrow_width, **kwargs):
             pair=e,
             x=pos[e[1]][0],
             y=pos[e[1]][1],
-            angle=atan2(Dy, Dx),
-            dy=arrow_width/2*sin(angle),
-            dx=arrow_width/2*cos(angle)
+            **G.edges[e]
+        )
+
+        data2 = dict(
+            edge=i,
+            source=e[0],
+            target=e[1],
+            pair=e,
+            x=pos[e[1]][0]-arrow_length*Dx,
+            y=pos[e[1]][1]-arrow_length*Dy,
             **G.edges[e]
         )
 
         df.loc[idx] = data1
+        df.loc[idx+1] = data2
 
     return df
 

--- a/nx_altair/core.py
+++ b/nx_altair/core.py
@@ -2,6 +2,7 @@ import pandas as pd
 import networkx as nx
 import altair as alt
 from ._utils import despine
+from math import atan2
 
 def to_pandas_nodes(G, pos):
     """Convert Graph nodes to pandas DataFrame that's readable to Altair.
@@ -73,6 +74,45 @@ def to_pandas_edges(G, pos, **kwargs):
 
         df.loc[idx] = data1
         df.loc[idx+1] = data2
+
+    return df
+
+def to_pandas_edges_arrows(G, pos, arrow_width, **kwargs):
+    """Convert Graph edges to pandas DataFrame that's readable to Altair.
+    """
+    # Get all attributes in nodes
+    attributes = ['source', 'target', 'x', 'y', 'edge', 'pair']
+    for e in G.edges():
+        attributes += list(G.edges[e].keys())
+    attributes = list(set(attributes))
+
+
+    # Build a dataframe for all edges and their attributes
+    df = pd.DataFrame(
+        index=range(G.size()),
+        columns=attributes
+    )
+
+
+    # Add node data to dataframe.
+    for i, e in enumerate(G.edges):
+        idx = i
+        Dy = pos[e[0]][1]-pos[e[0]][0]
+        Dx = pos[e[1]][1]-pos[e[1]][0]
+        data1 = dict(
+            edge=i,
+            source=e[0],
+            target=e[1],
+            pair=e,
+            x=pos[e[1]][0],
+            y=pos[e[1]][1],
+            angle=atan2(Dy, Dx),
+            dy=arrow_width/2*sin(angle),
+            dx=arrow_width/2*cos(angle)
+            **G.edges[e]
+        )
+
+        df.loc[idx] = data1
 
     return df
 

--- a/nx_altair/draw_altair.py
+++ b/nx_altair/draw_altair.py
@@ -73,7 +73,7 @@ def draw_networkx_edges(
     ###### node list argument
     if isinstance(edgelist, list):
         # Subset dataframe.
-        df_edges = df_edges.loc[df['pair'].isin(edgelist)]
+        df_edges = df_edges.loc[df_edges['pair'].isin(edgelist)]
 
     elif edgelist is not None:
         raise Exception("nodelist must be a list or None.")
@@ -144,9 +144,8 @@ def draw_networkx_arrows(
     chart=None,
     layer=None,
     edgelist=None,
-    arrow_height=1,
     arrow_width=2,
-    width=1,
+    arrow_length=.25,
     alpha=1.0,
     edge_color='black',
     edge_cmap=None,
@@ -171,8 +170,11 @@ def draw_networkx_arrows(
     edgelist : collection of edge tuples
        Draw only specified edges(default=G.edges())
 
-    width : float, or array of floats
-       Line width of edges (default=1.0)
+    arrow_width : float, optional (default=2.0)
+       The width of arrow portions of edges.
+
+    arrow_length : float, optional (default=.25)
+       The perportion of the line to be occupied by the arrow.
 
     edge_color : color string, or array of floats
        Edge color. Can be a single color format string (default='r'),
@@ -192,7 +194,7 @@ def draw_networkx_arrows(
     """
     if chart is None:
         # Pandas dataframe of edges
-        df_edge_arrows = to_pandas_edges_arrows(G, pos, arrow_width)
+        df_edge_arrows = to_pandas_edges_arrows(G, pos, arrow_length)
 
         # Build a chart
         edge_chart = alt.Chart(df_edge_arrows)
@@ -208,21 +210,21 @@ def draw_networkx_arrows(
     ###### node list argument
     if isinstance(edgelist, list):
         # Subset dataframe.
-        df_edge_arrows = df_edge_arrows.loc[df['pair'].isin(edgelist)]
+        df_edge_arrows = df_edge_arrows.loc[df_edge_arrows['pair'].isin(edgelist)]
 
     elif edgelist is not None:
         raise Exception("nodelist must be a list or None.")
 
 
     ###### Node size
-    if isinstance(width, str):
-        encoded_attrs["size"] = alt.Size(width, legend=None)
+    if isinstance(arrow_width, str):
+        encoded_attrs["size"] = alt.Size(arrow_width, legend=None)
 
-    elif isinstance(width, float) or isinstance(width, int):
-        marker_attrs["strokeWidth"] = width
+    elif isinstance(arrow_width, float) or isinstance(arrow_width, int):
+        marker_attrs["strokeWidth"] = arrow_width
 
     else:
-        raise Exception("width must be a string or int.")
+        raise Exception("arrow_width must be a string or int.")
 
     ###### node_color
     if not isinstance(edge_color, str):
@@ -260,17 +262,12 @@ def draw_networkx_arrows(
     # ---------- Construct visualization ------------
 
     # Draw edges
-    edge_chart = edge_chart.mark_rect(
-            baseline='middle',
-            height=arrow_height,
-            width=arrow_width,
-            **marker_attrs
+    edge_chart = edge_chart.mark_line(
+        **marker_attrs
     ).encode(
         x='x',
         y='y',
-        angle='angle',
-        dx='dx',
-        dy='dy',
+        detail='edge',
         **encoded_attrs
     )
 
@@ -436,6 +433,8 @@ def draw_networkx(
     alpha=1,
     cmap=None,
     width=1,
+    arrow_width=2,
+    arrow_length=.25,
     edge_color='black',
     node_tooltip=None,
     edge_tooltip=None,
@@ -468,6 +467,12 @@ def draw_networkx(
     width : float, optional (default=1.0)
        Line width of edges
 
+    arrow_width : float, optional (default=2.0)
+       The width of arrow portions of edges.
+
+    arrow_length : float, optional (default=.25)
+       The perportion of the line to be occupied by the arrow.
+
     edge_color : color string, or array of floats (default='r')
        Edge color. Can be a single color format string,
        or a sequence of colors with the same length as edgelist.
@@ -496,7 +501,8 @@ def draw_networkx(
             pos,
             edgelist=edgelist,
             alpha=alpha,
-            width=width,
+            arrow_width=arrow_width,
+            arrow_length=arrow_length,
             edge_color=edge_color,
             edge_cmap=edge_cmap,
             tooltip=edge_tooltip,

--- a/nx_altair/draw_altair.py
+++ b/nx_altair/draw_altair.py
@@ -145,7 +145,7 @@ def draw_networkx_arrows(
     layer=None,
     edgelist=None,
     arrow_width=2,
-    arrow_length=.25,
+    arrow_length=.1,
     alpha=1.0,
     edge_color='black',
     edge_cmap=None,
@@ -173,7 +173,7 @@ def draw_networkx_arrows(
     arrow_width : float, optional (default=2.0)
        The width of arrow portions of edges.
 
-    arrow_length : float, optional (default=.25)
+    arrow_length : float, optional (default=.1)
        The perportion of the line to be occupied by the arrow.
 
     edge_color : color string, or array of floats
@@ -434,8 +434,9 @@ def draw_networkx(
     cmap=None,
     width=1,
     arrow_width=2,
-    arrow_length=.25,
+    arrow_length=.1,
     edge_color='black',
+    arrow_color='black',
     node_tooltip=None,
     edge_tooltip=None,
     edge_cmap=None):
@@ -470,11 +471,17 @@ def draw_networkx(
     arrow_width : float, optional (default=2.0)
        The width of arrow portions of edges.
 
-    arrow_length : float, optional (default=.25)
+    arrow_length : float, optional (default=.1)
        The perportion of the line to be occupied by the arrow.
 
     edge_color : color string, or array of floats (default='r')
        Edge color. Can be a single color format string,
+       or a sequence of colors with the same length as edgelist.
+       If numeric values are specified they will be mapped to
+       colors using the edge_cmap and edge_vmin,edge_vmax parameters.
+    
+    arrow_color : color string, or array of floats (default='r')
+       Arrow color. Can be a single color format string,
        or a sequence of colors with the same length as edgelist.
        If numeric values are specified they will be mapped to
        colors using the edge_cmap and edge_vmin,edge_vmax parameters.
@@ -503,7 +510,7 @@ def draw_networkx(
             alpha=alpha,
             arrow_width=arrow_width,
             arrow_length=arrow_length,
-            edge_color=edge_color,
+            edge_color=arrow_color,
             edge_cmap=edge_cmap,
             tooltip=edge_tooltip,
             )
@@ -522,7 +529,7 @@ def draw_networkx(
 
     # Layer the chart
     if isinstance(G, nx.DiGraph):
-        viz = edges + nodes + arrows
+        viz = edges + arrows + nodes
     else:
         viz = edges + nodes
 


### PR DESCRIPTION
added `to_pandas_edges_arrows` to `core.py` which calculates portions of the line to be shown as arrows.

added `draw_networkx_arrows` to `draw_altair.py` which draws the arrows as rectangles on the lines. Added parameters:
* `arrow_width` : float, optional (default=2.0)
       The width of arrow portions of edges.

* `arrow_length` : float, optional (default=.25)
       The proportion of the line to be occupied by the arrow.

Not dependent on my other pull request. Will require a merge to put them together, only conflict will be in `draw_networkx` due to the if statements.

Graphs look similar to a DiGraph in networkx base package plotting. Arrows are only appied if `G` isinstance `nx.DiGraph`.