### PR TITLE
resolve multigraph issue with value unpacking

### DIFF
--- a/nx_altair/core.py
+++ b/nx_altair/core.py
@@ -35,8 +35,9 @@ def to_pandas_edges(G, pos, **kwargs):
     """
     # Get all attributes in nodes
     attributes = ['source', 'target', 'x', 'y', 'edge', 'pair']
-    for e in G.edges():
-        attributes += list(G.edges[e].keys())
+    if not (isinstance(G, nx.MultiGraph)):
+        for e in G.edges():
+            attributes += list(G.edges[e].keys())
     attributes = list(set(attributes))
 
 


### PR DESCRIPTION
Addressing issue #13 
Currently, when trying to convert a networkx multigraph, a ValueError is thrown. This is caused by to_pandas_edges, where the edge keys are added to the attributes. 
This PR simply checks if the graph is a multigraph, and if so, skips this step.